### PR TITLE
fix(codex): update zotero mcp setup docs and installer hint

### DIFF
--- a/MCP_SETUP.md
+++ b/MCP_SETUP.md
@@ -8,7 +8,7 @@ Claude Scholar relies on MCP (Model Context Protocol) servers for extended capab
 
 **Used by**: `literature-reviewer` agent, `research-ideation` skill, and research workflow skills (triggered via natural language)
 
-**Package**: [Galaxy-Dawn/zotero-mcp](https://github.com/Galaxy-Dawn/zotero-mcp) — Web API mode, supports remote access without Zotero desktop app.
+**Package**: [Galaxy-Dawn/zotero-mcp](https://github.com/Galaxy-Dawn/zotero-mcp) — auto-detects local Zotero desktop vs Web API mode; Web credentials are required for remote access and write tools.
 
 #### Features
 
@@ -23,7 +23,9 @@ Claude Scholar relies on MCP (Model Context Protocol) servers for extended capab
 #### Prerequisites
 
 1. Install [Zotero](https://www.zotero.org/) (optional, for local mode)
-2. Get Zotero API key and library ID from [zotero.org/settings/keys](https://www.zotero.org/settings/keys)
+2. For Web API access, open [Zotero Settings -> Security -> Applications](https://www.zotero.org/settings/security#applications)
+3. Click `Create new private key` to generate your API key
+4. On the same page, the `User ID` shown below the button is the value to use as `ZOTERO_LIBRARY_ID` for a personal library
 
 #### Installation
 
@@ -48,7 +50,7 @@ enabled = true
 
 [mcp_servers.zotero.env]
 ZOTERO_API_KEY = "your-api-key"
-ZOTERO_LIBRARY_ID = "your-library-id"
+ZOTERO_LIBRARY_ID = "your-user-id"
 ZOTERO_LIBRARY_TYPE = "user"
 UNPAYWALL_EMAIL = "your-email@example.com"
 UNSAFE_OPERATIONS = "all"
@@ -67,7 +69,7 @@ Add to your `~/.claude/settings.json`:
       "args": ["serve"],
       "env": {
         "ZOTERO_API_KEY": "your-api-key",
-        "ZOTERO_LIBRARY_ID": "your-library-id",
+        "ZOTERO_LIBRARY_ID": "your-user-id",
         "ZOTERO_LIBRARY_TYPE": "user",
         "UNPAYWALL_EMAIL": "your-email@example.com",
         "UNSAFE_OPERATIONS": "all"
@@ -98,7 +100,7 @@ Then set environment variables in `~/.zshrc`:
 ```bash
 # Zotero MCP
 export ZOTERO_API_KEY="your-api-key"
-export ZOTERO_LIBRARY_ID="your-library-id"
+export ZOTERO_LIBRARY_ID="your-user-id"
 export ZOTERO_LIBRARY_TYPE="user"
 export UNPAYWALL_EMAIL="your-email@example.com"
 export UNSAFE_OPERATIONS="all"
@@ -108,12 +110,16 @@ export UNSAFE_OPERATIONS="all"
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `ZOTERO_API_KEY` | Yes | Your Zotero API key |
-| `ZOTERO_LIBRARY_ID` | Yes | Your library ID (numeric) |
+| `ZOTERO_API_KEY` | No for local read-only; Yes for Web/write tools | Your Zotero API key |
+| `ZOTERO_LIBRARY_ID` | No for local read-only; Yes for Web/write tools | Your Zotero `User ID` (numeric) for personal libraries |
 | `ZOTERO_LIBRARY_TYPE` | Yes | `user` or `group` |
 | `UNPAYWALL_EMAIL` | No | Email for Unpaywall PDF search |
 | `UNSAFE_OPERATIONS` | No | `items` (delete_items), `all` (delete_collection) |
 | `NO_PROXY` | No | Bypass proxy for localhost |
+
+Notes:
+- The minimal local setup is just `command = "zotero-mcp"` plus `args = ["serve"]`.
+- Do not leave placeholder values such as `your-api-key`, `your-user-id`, or `your-email@example.com` in your live config.
 
 #### Available Tools
 

--- a/MCP_SETUP.zh-CN.md
+++ b/MCP_SETUP.zh-CN.md
@@ -8,7 +8,7 @@ Claude Scholar 依赖 MCP（Model Context Protocol）服务器提供扩展功能
 
 **使用者**: `literature-reviewer` 代理、`research-ideation` skill 及研究工作流技能（通过自然语言触发）
 
-**包**: [Galaxy-Dawn/zotero-mcp](https://github.com/Galaxy-Dawn/zotero-mcp) — Web API 模式，支持远程访问，无需 Zotero 桌面应用。
+**包**: [Galaxy-Dawn/zotero-mcp](https://github.com/Galaxy-Dawn/zotero-mcp) — 可自动识别本地 Zotero desktop 与 Web API 模式；远程访问和写操作时需要 Web 凭证。
 
 #### 功能
 
@@ -23,7 +23,9 @@ Claude Scholar 依赖 MCP（Model Context Protocol）服务器提供扩展功能
 #### 前置条件
 
 1. 安装 [Zotero](https://www.zotero.org/)（可选，用于本地模式）
-2. 从 [zotero.org/settings/keys](https://www.zotero.org/settings/keys) 获取 Zotero API 密钥和库 ID
+2. 如需使用 Web API，请打开 [Zotero 设置 -> Security -> Applications](https://www.zotero.org/settings/security#applications)
+3. 点击 `Create new private key` 生成 API key
+4. 同一页面按钮下方显示的 `User ID`，就是个人库场景下应填写的 `ZOTERO_LIBRARY_ID`
 
 #### 安装
 
@@ -48,7 +50,7 @@ enabled = true
 
 [mcp_servers.zotero.env]
 ZOTERO_API_KEY = "your-api-key"
-ZOTERO_LIBRARY_ID = "your-library-id"
+ZOTERO_LIBRARY_ID = "your-user-id"
 ZOTERO_LIBRARY_TYPE = "user"
 UNPAYWALL_EMAIL = "your-email@example.com"
 UNSAFE_OPERATIONS = "all"
@@ -67,7 +69,7 @@ NO_PROXY = "localhost,127.0.0.1"
       "args": ["serve"],
       "env": {
         "ZOTERO_API_KEY": "your-api-key",
-        "ZOTERO_LIBRARY_ID": "your-library-id",
+        "ZOTERO_LIBRARY_ID": "your-user-id",
         "ZOTERO_LIBRARY_TYPE": "user",
         "UNPAYWALL_EMAIL": "your-email@example.com",
         "UNSAFE_OPERATIONS": "all"
@@ -98,7 +100,7 @@ NO_PROXY = "localhost,127.0.0.1"
 ```bash
 # Zotero MCP
 export ZOTERO_API_KEY="your-api-key"
-export ZOTERO_LIBRARY_ID="your-library-id"
+export ZOTERO_LIBRARY_ID="your-user-id"
 export ZOTERO_LIBRARY_TYPE="user"
 export UNPAYWALL_EMAIL="your-email@example.com"
 export UNSAFE_OPERATIONS="all"
@@ -108,12 +110,16 @@ export UNSAFE_OPERATIONS="all"
 
 | 变量 | 必需 | 说明 |
 |------|------|------|
-| `ZOTERO_API_KEY` | 是 | 你的 Zotero API 密钥 |
-| `ZOTERO_LIBRARY_ID` | 是 | 你的库 ID（数字） |
+| `ZOTERO_API_KEY` | 本地只读可不填；Web/写操作必填 | 你的 Zotero API 密钥 |
+| `ZOTERO_LIBRARY_ID` | 本地只读可不填；Web/写操作必填 | 个人库场景下填写 Zotero 页面显示的 `User ID`（数字） |
 | `ZOTERO_LIBRARY_TYPE` | 是 | `user` 或 `group` |
 | `UNPAYWALL_EMAIL` | 否 | 用于 Unpaywall PDF 搜索的邮箱 |
 | `UNSAFE_OPERATIONS` | 否 | `items`（启用 delete_items）、`all`（启用 delete_collection） |
 | `NO_PROXY` | 否 | 绕过 localhost 代理 |
+
+说明：
+- 最小本地配置只需要 `command = "zotero-mcp"` 和 `args = ["serve"]`。
+- 不要把 `your-api-key`、`your-user-id`、`your-email@example.com` 这类占位符直接保留在正式配置里。
 
 #### 可用工具
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -310,7 +310,7 @@ configure_mcp() {
     rm -f "$CODEX_HOME/config.toml.tmp"
     info "Zotero MCP enabled"
     if ! command -v zotero-mcp >/dev/null 2>&1; then
-      warn "zotero-mcp not found. Install: uv tool install zotero-mcp-server"
+      warn "zotero-mcp not found. Install: uv tool install git+https://github.com/Galaxy-Dawn/zotero-mcp.git"
     fi
   fi
 }


### PR DESCRIPTION
## Summary

This PR fixes a few outdated Zotero MCP setup details on the Codex branch.

## Changes

- Update the Zotero credential setup link in `MCP_SETUP.md` and `MCP_SETUP.zh-CN.md`
  - from the old `https://www.zotero.org/settings/keys`
  - to `https://www.zotero.org/settings/security#applications`
- Clarify the correct credential retrieval flow
  - create a new private key from the Applications page
  - use the displayed `User ID` as `ZOTERO_LIBRARY_ID` for personal libraries
- Update example values from `your-library-id` to `your-user-id` where appropriate
- Improve environment variable descriptions for local read-only vs Web/write usage
- Fix the Codex installer warning in `scripts/setup.sh`
  - from `uv tool install zotero-mcp-server`
  - to `uv tool install git+https://github.com/Galaxy-Dawn/zotero-mcp.git`

## Why

Some users were still following outdated setup instructions, which could lead to incorrect Zotero MCP configuration on Codex.

## Scope

This is a documentation and installer-hint fix only. No functional runtime logic was changed.