### PR TITLE
feat(plugin): add Claude Code marketplace installation support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "claude-scholar",
+  "owner": {
+    "name": "Galaxy-Dawn"
+  },
+  "metadata": {
+    "description": "Semi-automated research assistant for academic research and software development",
+    "homepage": "https://github.com/Galaxy-Dawn/claude-scholar"
+  },
+  "plugins": [
+    {
+      "name": "claude-scholar",
+      "version": "1.0.0",
+      "source": ".",
+      "description": "Semi-automated research assistant with skills for literature review, experiments, analysis, writing, and project knowledge management"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "claude-scholar",
+  "version": "1.0.0",
+  "description": "Semi-automated research assistant for academic research and software development, with skills for literature review, experiments, analysis, writing, and project knowledge management",
+  "author": {
+    "name": "Galaxy-Dawn"
+  },
+  "repository": "https://github.com/Galaxy-Dawn/claude-scholar",
+  "license": "MIT",
+  "keywords": [
+    "research",
+    "academic",
+    "paper-writing",
+    "literature-review",
+    "experiments",
+    "obsidian",
+    "zotero",
+    "ml",
+    "ai"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,7 @@
     "name": "Galaxy-Dawn"
   },
   "repository": "https://github.com/Galaxy-Dawn/claude-scholar",
+  "homepage": "https://github.com/Galaxy-Dawn/claude-scholar",
   "license": "MIT",
   "keywords": [
     "research",

--- a/README.md
+++ b/README.md
@@ -172,6 +172,29 @@ cp rules/agents.md ~/.claude/rules/
 
 **Post-install**: selective/manual install does **not** auto-merge `settings.json`; copy only the hooks or MCP entries you actually want from `settings.json.template`. If you already have your own `~/.claude/CLAUDE.md` or `~/.claude/CLAUDE.zh-CN.md`, merge the relevant sections from this repo's Claude files into yours instead of blindly overwriting them.
 
+### Option 4: Plugin Marketplace Installation
+
+**Step 1: Install the Plugin**
+
+```bash
+/plugin marketplace add Galaxy-Dawn/claude-scholar
+/plugin install claude-scholar@claude-scholar
+```
+
+This auto-loads all skills, commands, agents, and hooks.
+
+**Step 2: Install Rules (Required)**
+
+Claude Code plugins cannot distribute rules automatically. Install them manually:
+
+```bash
+git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+mkdir -p ~/.claude/rules
+cp /tmp/claude-scholar/rules/*.md ~/.claude/rules/
+```
+
+> **Note**: Plugin installation does not configure `settings.json` (MCP servers, env vars). If you need Zotero MCP or other integrations, see the [Integrations](#integrations) section for manual setup.
+
 ## Getting Started Scenarios
 
 After installation, the simplest way to begin is to describe your task in natural language. You do not need to memorize the whole system first. Below are a few realistic starting points.
@@ -223,7 +246,6 @@ or:
 - Start with one concrete task, not a vague request for "everything."
 - If you already maintain your own local `CLAUDE.md` files, merge the Claude Scholar sections you want into them instead of assuming sidecar files apply automatically.
 - Zotero and Obsidian are optional, but they become much more useful when you want durable literature notes or project memory rather than one-off chat output.
-
 
 ## Platform Support
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ cp rules/agents.md ~/.claude/rules/
 /plugin install claude-scholar@claude-scholar
 ```
 
-This auto-loads all skills, commands, agents, and hooks.
+This auto-loads all skills, commands, agents, and hooks. During installation, you can choose the scope: user (all projects) or project (single project).
 
 **Step 2: Install Rules (Required)**
 
@@ -189,8 +189,14 @@ Claude Code plugins cannot distribute rules automatically. Install them manually
 
 ```bash
 git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+
+# User-level (all projects)
 mkdir -p ~/.claude/rules
 cp /tmp/claude-scholar/rules/*.md ~/.claude/rules/
+
+# Or project-level (current project only)
+mkdir -p .claude/rules
+cp /tmp/claude-scholar/rules/*.md .claude/rules/
 ```
 
 > **Note**: Plugin installation does not configure `settings.json` (MCP servers, env vars). If you need Zotero MCP or other integrations, see the [Integrations](#integrations) section for manual setup.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ mkdir -p .claude/rules
 cp /tmp/claude-scholar/rules/*.md .claude/rules/
 ```
 
-> **Note**: Plugin installation does not configure `settings.json` (MCP servers, env vars). If you need Zotero MCP or other integrations, see the [Integrations](#integrations) section for manual setup.
+**Post-install**: plugin installation does **not** auto-load `CLAUDE.md` or configure `settings.json`; if you already have your own `~/.claude/CLAUDE.md` or `~/.claude/CLAUDE.zh-CN.md`, merge the relevant Claude Scholar sections into yours instead of assuming the plugin applies them automatically. If you need Zotero MCP or other integrations, see the [Integrations](#integrations) section for manual setup.
 
 ## Getting Started Scenarios
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -172,6 +172,29 @@ cp rules/agents.md ~/.claude/rules/
 
 **安装后**：选择性/手动安装**不会自动合并** `settings.json`；请按需从 `settings.json.template` 复制你需要的 hooks 或 MCP 条目。如果你已经有自己的 `~/.claude/CLAUDE.md` 或 `~/.claude/CLAUDE.zh-CN.md`，也请把仓库提供的相关内容按需 merge 到你的文件里，而不是直接覆盖。
 
+### 选项 4：插件市场安装
+
+**第一步：安装插件**
+
+```bash
+/plugin marketplace add Galaxy-Dawn/claude-scholar
+/plugin install claude-scholar@claude-scholar
+```
+
+自动加载所有 skills、commands、agents 和 hooks。
+
+**第二步：安装 Rules（必须）**
+
+Claude Code 插件无法自动分发 rules，需要手动安装：
+
+```bash
+git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+mkdir -p ~/.claude/rules
+cp /tmp/claude-scholar/rules/*.md ~/.claude/rules/
+```
+
+> **注意**：插件安装不会配置 `settings.json`（MCP 服务器、环境变量等）。如需 Zotero MCP 或其他集成，请参阅[集成能力](#集成能力)部分手动设置。
+
 ## 上手场景
 
 安装完成后，最简单的上手方式就是直接用自然语言描述你的任务，不需要先把整套系统全部背下来。下面给几种最常见、也最实用的起步场景。
@@ -220,10 +243,9 @@ cp rules/agents.md ~/.claude/rules/
 - 还需要补验证或补材料的点。
 
 ### 使用建议
-- 先从一个具体任务开始，而不是一上来让系统“把所有事情都做了”。
+- 先从一个具体任务开始，而不是一上来让系统”把所有事情都做了”。
 - 如果你已经有自己的本地 `CLAUDE.md` 文件，请把你需要的 Claude Scholar 内容按需 merge 进去，不要假设 sidecar 文件会自动生效。
 - Zotero 和 Obsidian 都不是强制的，但如果你希望得到 durable literature notes 或 project memory，而不是一次性聊天输出，它们会非常有帮助。
-
 
 ## 平台支持
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -181,7 +181,7 @@ cp rules/agents.md ~/.claude/rules/
 /plugin install claude-scholar@claude-scholar
 ```
 
-自动加载所有 skills、commands、agents 和 hooks。
+自动加载所有 skills、commands、agents 和 hooks。安装时可选择作用范围：user（所有项目）或 project（单个项目）。
 
 **第二步：安装 Rules（必须）**
 
@@ -189,8 +189,14 @@ Claude Code 插件无法自动分发 rules，需要手动安装：
 
 ```bash
 git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+
+# 用户级（所有项目生效）
 mkdir -p ~/.claude/rules
 cp /tmp/claude-scholar/rules/*.md ~/.claude/rules/
+
+# 或项目级（仅当前项目生效）
+mkdir -p .claude/rules
+cp /tmp/claude-scholar/rules/*.md .claude/rules/
 ```
 
 > **注意**：插件安装不会配置 `settings.json`（MCP 服务器、环境变量等）。如需 Zotero MCP 或其他集成，请参阅[集成能力](#集成能力)部分手动设置。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -199,7 +199,7 @@ mkdir -p .claude/rules
 cp /tmp/claude-scholar/rules/*.md .claude/rules/
 ```
 
-> **注意**：插件安装不会配置 `settings.json`（MCP 服务器、环境变量等）。如需 Zotero MCP 或其他集成，请参阅[集成能力](#集成能力)部分手动设置。
+**安装后**：插件安装**不会**自动加载 `CLAUDE.md` 或配置 `settings.json`；如果你已经有自己的 `~/.claude/CLAUDE.md` 或 `~/.claude/CLAUDE.zh-CN.md`，也请把仓库提供的相关内容按需 merge 到你的文件里，而不是假设插件会自动应用。如需 Zotero MCP 或其他集成，请参阅[集成能力](#集成能力)部分手动设置。
 
 ## 上手场景
 


### PR DESCRIPTION
## Motivation

Currently claude-scholar can only be installed via `setup.sh` (Option 1) or manual file copying (Options 2/3). The Claude Code plugin marketplace provides a simpler and more flexible installation path.

> **Note**: This PR targets the `main` branch (Claude Code). The `codex` and `opencode` branches are not affected — they have their own installation methods.

Key benefits of marketplace installation:
- **Enable/disable on demand** — toggle claude-scholar on or off without adding or removing files from `~/.claude/`
- **Scoped installation** — install at user level (all projects) or project level (single project)
- **No file conflicts** — plugin components are namespaced and isolated in the plugin cache, avoiding collisions with the user's existing `~/.claude/` configuration

## What changed

### New files

- **`.claude-plugin/plugin.json`** — Plugin manifest with name, version, description, author, repository, license, and keywords. No component arrays — Claude Code auto-discovers `skills/`, `commands/`, `agents/`, and `hooks/hooks.json` by convention.
- **`.claude-plugin/marketplace.json`** — Marketplace catalog required by `/plugin marketplace add` to expose the plugin for installation.

### Modified files

- **`README.md`** — Added "Option 4: Plugin Marketplace Installation" after existing options, with two-step instructions and a note about manual rules/settings.json setup.
- **`README.zh-CN.md`** — Same addition in Chinese.

### What's NOT changed

- `hooks/hooks.json` — already plugin-compatible (uses `${CLAUDE_PLUGIN_ROOT}`)
- `scripts/setup.sh` — unaffected, backward compatible
- All existing installation options remain unchanged

## Plugin system limitation: rules

Claude Code plugins cannot distribute `rules/` automatically ([official docs](https://code.claude.com/docs/en/plugins)). Only `skills/`, `commands/`, `agents/`, `hooks/`, `.mcp.json`, `.lsp.json`, and `settings.json` are copied to the plugin cache.

The README documents a manual copy step for the 5 rule files after plugin installation. Rules can be installed at either scope:

- **User-level** (`~/.claude/rules/`) — applies to all projects
- **Project-level** (`.claude/rules/`) — applies to single project

## How to install

**Step 1: Install the plugin**
```bash
/plugin marketplace add Galaxy-Dawn/claude-scholar
/plugin install claude-scholar@claude-scholar
```

**Step 2: Install rules (required)**
```bash
git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar

# User-level (all projects)
mkdir -p ~/.claude/rules
cp /tmp/claude-scholar/rules/*.md ~/.claude/rules/

# Or project-level (single project)
mkdir -p .claude/rules
cp /tmp/claude-scholar/rules/*.md .claude/rules/
```

## Testing

- `claude plugin validate .claude-plugin/plugin.json` — manifest passes validation (pre-existing YAML errors in some upstream agent/command frontmatter are unrelated)
- `claude --plugin-dir ./` — all 47 skills, 62 commands, 15 agents, and 5 hooks load correctly