### PR TITLE
fix(marketplace): use valid relative path in plugin source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "claude-scholar",
       "version": "1.0.0",
-      "source": ".",
+      "source": "./",
       "description": "Semi-automated research assistant with skills for literature review, experiments, analysis, writing, and project knowledge management"
     }
   ]


### PR DESCRIPTION
## Summary
- Changed `source` from `"."` to `"./"` in `.claude-plugin/marketplace.json`
- Claude Code requires relative paths to start with `./` per the [marketplace schema specification](https://code.claude.com/docs/en/plugin-marketplaces#relative-paths)
- The bare `"."` causes a validation error (`plugins.0.source: Invalid input`) when adding the marketplace via `/plugin marketplace add`