### PR TITLE
Add compatibility with Antigravity 2.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # System files
 .DS_Store
 Thumbs.db
+.idea
 
 # Sensitive and local configuration
 .env

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -114,30 +114,35 @@ Claude Scholarは特に以下のような方に適しています:
 
 ### オプション1: フルインストール（推奨）
 
+**Linux / macOS**:
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
 bash /tmp/claude-scholar/scripts/setup.sh
 ```
 
-**Windows**: インストーラーの実行にはGit BashまたはWSLをご使用ください。
+**Windows (PowerShell)**:
+```powershell
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git C:\Temp\claude-scholar
+powershell -ExecutionPolicy Bypass -File C:\Temp\claude-scholar\scripts\setup.ps1
+```
 
 インストーラーは**バックアップ対応かつインクリメンタルアップデートに対応**しています:
-- リポジトリ管理の`skills/commands/agents/rules/hooks/scripts/CLAUDE*.md`を更新
-- 上書きされるファイルを`~/.claude/.claude-scholar-backups/<timestamp>/`にバックアップ
-- `settings.json`を`settings.json.bak`にバックアップ
-- 既存の`~/.claude/CLAUDE.md`を保持し、リポジトリ版を`~/.claude/CLAUDE.scholar.md`としてインストール
-- 既存の`~/.claude/CLAUDE.zh-CN.md`を保持し、リポジトリ版を`~/.claude/CLAUDE.zh-CN.scholar.md`としてインストール
+- リポジトリ管理の`skills/commands/agents/rules/hooks/scripts/CLAUDE*.md`をプラグインディレクトリ`~/.gemini/config/plugins/claude-scholar/`に直接更新
+- 上書きされるファイルを`~/.gemini/config/plugins/claude-scholar/.claude-scholar-backups/<timestamp>/`にバックアップ
+- `mcp_config.json`を`mcp_config.json.bak`にバックアップ
+- 既存の`~/.gemini/config/plugins/claude-scholar/CLAUDE.md`を保持し、リポジトリ版を`~/.gemini/config/plugins/claude-scholar/CLAUDE.scholar.md`としてインストール
+- 既存の`~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`を保持し、リポジトリ版を`~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.scholar.md`としてインストール
 - 既存の`env`、モデル/プロバイダー設定、APIキー、パーミッション、現在の`mcpServers`値を保持
-- 既存のフックセットを置き換えるのではなく、不足しているフックエントリを追加
+- 必要なMCPサーバーを`~/.gemini/config/mcp_config.json`にマージし、既存のすべての設定を置き換えることはありません
 
-**CLAUDEに関する重要事項**: 既に独自の`~/.claude/CLAUDE.md`や`~/.claude/CLAUDE.zh-CN.md`をお持ちの場合、インストール後に`~/.claude/CLAUDE.scholar.md`と`~/.claude/CLAUDE.zh-CN.scholar.md`を確認し、必要なClaude Scholarのセクションを手動で統合してください。別名で配置された補助ファイルは自動的には適用されません。
+**CLAUDEに関する重要事項**: 既に独自の`~/.gemini/config/plugins/claude-scholar/CLAUDE.md`や`~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`をお持ちの場合、インストール後にサイドカー`.scholar.md`ファイルを確認し、必要なClaude Scholarのセクションを手动で統合してください。別名で配置された補助ファイルは自動的には適用されません。
 
 アップデート方法:
 
 ```bash
-cd /tmp/claude-scholar
+cd /tmp/claude-scholar  # Windowsでは C:\Temp\claude-scholar
 git pull --ff-only
-bash scripts/setup.sh
+bash scripts/setup.sh   # Windowsでは powershell -ExecutionPolicy Bypass -File scripts/setup.ps1
 ```
 
 アンインストールする場合:
@@ -148,8 +153,8 @@ bash scripts/uninstall.sh
 ```
 
 インストーラーは次のファイルも書き込みます:
-- `~/.claude/.claude-scholar-manifest.txt`: Claude Scholar が実際に管理するファイル一覧
-- `~/.claude/.claude-scholar-install-state`: 安全なアンインストールに使う ownership メタデータ
+- `~/.gemini/config/plugins/claude-scholar/.claude-scholar-manifest.txt`: Claude Scholar が実際に管理するファイル一覧
+- `~/.gemini/config/plugins/claude-scholar/.claude-scholar-install-state`: 安全なアンインストールに使う ownership メタデータ
 
 アンインストーラーは install state に記録されたファイルと settings エントリだけを削除し、現在のリポジトリ内容から所有権を推測しません。
 
@@ -158,38 +163,38 @@ bash scripts/uninstall.sh
 研究にフォーカスした最小限のサブセットのみをインストール:
 
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
-mkdir -p ~/.claude/hooks ~/.claude/skills
-cp /tmp/claude-scholar/hooks/*.js ~/.claude/hooks/
-cp -r /tmp/claude-scholar/skills/ml-paper-writing ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/research-ideation ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/results-analysis ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/results-report ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/review-response ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/writing-anti-ai ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/git-workflow ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/bug-detective ~/.claude/skills/
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+mkdir -p ~/.gemini/config/plugins/claude-scholar/hooks ~/.gemini/config/plugins/claude-scholar/skills
+cp /tmp/claude-scholar/hooks/*.js ~/.gemini/config/plugins/claude-scholar/hooks/
+cp -r /tmp/claude-scholar/skills/ml-paper-writing ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/research-ideation ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/results-analysis ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/results-report ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/review-response ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/writing-anti-ai ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/git-workflow ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/bug-detective ~/.gemini/config/plugins/claude-scholar/skills/
 ```
 
-**インストール後**: ミニマル/手動インストールでは`settings.json`の自動統合は行われません。`settings.json.template`から必要なhooksやMCPエントリのみをコピーしてください。既に独自の`~/.claude/CLAUDE.md`や`~/.claude/CLAUDE.zh-CN.md`をお持ちの場合は、上書きせずにこのリポジトリのCLAUDEファイルから関連セクションを統合してください。
+**インストール後**: ミニマル/手動インストールでは`mcp_config.json`の自動統合は行われません。`settings.json.template`から必要なMCPエントリのみを`~/.gemini/config/mcp_config.json`にコピーしてください。既に独自の`~/.gemini/config/plugins/claude-scholar/CLAUDE.md`や`~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`をお持ちの場合は、上書きせずにこのリポジトリのCLAUDEファイルから関連セクションを統合してください。
 
 ### オプション3: 選択的インストール
 
 必要な部分のみをコピー:
 
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
 cd /tmp/claude-scholar
 
-cp hooks/*.js ~/.claude/hooks/
-cp -r skills/latex-conference-template-organizer ~/.claude/skills/
-cp -r skills/architecture-design ~/.claude/skills/
-cp agents/paper-miner.md ~/.claude/agents/
-cp rules/coding-style.md ~/.claude/rules/
-cp rules/agents.md ~/.claude/rules/
+cp hooks/*.js ~/.gemini/config/plugins/claude-scholar/hooks/
+cp -r skills/latex-conference-template-organizer ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r skills/architecture-design ~/.gemini/config/plugins/claude-scholar/skills/
+cp agents/paper-miner.md ~/.gemini/config/plugins/claude-scholar/agents/
+cp rules/coding-style.md ~/.gemini/config/plugins/claude-scholar/rules/
+cp rules/agents.md ~/.gemini/config/plugins/claude-scholar/rules/
 ```
 
-**インストール後**: 選択的/手動インストールでは`settings.json`の自動統合は行われません。`settings.json.template`から実際に必要なhooksやMCPエントリのみをコピーしてください。既に独自の`~/.claude/CLAUDE.md`や`~/.claude/CLAUDE.zh-CN.md`をお持ちの場合は、上書きせずに関連セクションを統合してください。
+**インストール後**: 選択的/手動インストールでは`mcp_config.json`の自動統合は行われません。`settings.json.template`から実際に必要なMCPエントリのみを`~/.gemini/config/mcp_config.json`にコピーしてください。既に独自の`~/.gemini/config/plugins/claude-scholar/CLAUDE.md`や`~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`をお持ちの場合は、上書きせずに関連セクションを統合してください。
 
 ### オプション4: プラグインマーケットプレイス経由のインストール
 
@@ -204,21 +209,21 @@ cp rules/agents.md ~/.claude/rules/
 
 **ステップ2: ルールをインストール（必須）**
 
-Claude Code のプラグインは rules を自動配布できないため、手動で追加してください:
+Claude Code のプラグインは rules を自动配布できないため、手动で追加してください:
 
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
 
 # ユーザー全体（全プロジェクト）
-mkdir -p ~/.claude/rules
-cp /tmp/claude-scholar/rules/*.md ~/.claude/rules/
+mkdir -p ~/.gemini/config/plugins/claude-scholar/rules
+cp /tmp/claude-scholar/rules/*.md ~/.gemini/config/plugins/claude-scholar/rules/
 
 # あるいはプロジェクト単位（現在のプロジェクトのみ）
 mkdir -p .claude/rules
 cp /tmp/claude-scholar/rules/*.md .claude/rules/
 ```
 
-**インストール後**: プラグインインストールでは `CLAUDE.md` の自動読み込みや `settings.json` の自動設定は行われません。既に独自の `~/.claude/CLAUDE.md` や `~/.claude/CLAUDE.zh-CN.md` をお持ちの場合は、プラグインが自動適用すると考えず、Claude Scholar 側の関連セクションを手動で統合してください。Zotero MCP などの連携が必要な場合は、[連携ツール](#連携ツール) セクションを参照してください。
+**インストール後**: プラグインインストールでは `CLAUDE.md` の自动読み込みや `mcp_config.json` の自动設定は行われません。既に独自の `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` や `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md` をお持ちの場合は、プラグインが自动適用すると考えず、Claude Scholar 側の関連セクションを手动で統合してください。Zotero MCP などの連携が必要な場合は、[連携ツール](#連携ツール) セクションを参照してください。
 
 ## 使い始めのシナリオ
 

--- a/README.md
+++ b/README.md
@@ -120,30 +120,35 @@ Each stage should preserve what is known, what is uncertain, and what decision s
 
 ### Option 1: Full Installation (Recommended)
 
+**Linux / macOS**:
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
 bash /tmp/claude-scholar/scripts/setup.sh
 ```
 
-**Windows**: please use Git Bash or WSL to run the installer.
+**Windows (PowerShell)**:
+```powershell
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git C:\Temp\claude-scholar
+powershell -ExecutionPolicy Bypass -File C:\Temp\claude-scholar\scripts\setup.ps1
+```
 
 The installer is **backup-aware and incremental-update friendly**:
-- updates repo-managed `skills/commands/agents/rules/hooks/scripts/CLAUDE*.md`,
-- backs up overwritten files to `~/.claude/.claude-scholar-backups/<timestamp>/`,
-- backs up `settings.json` to `settings.json.bak`,
-- preserves an existing `~/.claude/CLAUDE.md` and installs the repo-managed version as `~/.claude/CLAUDE.scholar.md`,
-- preserves an existing `~/.claude/CLAUDE.zh-CN.md` and installs the repo-managed version as `~/.claude/CLAUDE.zh-CN.scholar.md`,
+- updates repo-managed `skills/commands/agents/rules/hooks/scripts/CLAUDE*.md` directly in the plugin directory `~/.gemini/config/plugins/claude-scholar/`,
+- backs up overwritten files to `~/.gemini/config/plugins/claude-scholar/.claude-scholar-backups/<timestamp>/`,
+- backs up `mcp_config.json` to `mcp_config.json.bak`,
+- preserves an existing `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` and installs the repo-managed version as `~/.gemini/config/plugins/claude-scholar/CLAUDE.scholar.md`,
+- preserves an existing `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md` and installs the repo-managed version as `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.scholar.md`,
 - preserves your existing `env`, model/provider settings, API keys, permissions, and current `mcpServers` values,
-- adds missing hook entries instead of replacing your entire hook set.
+- merges necessary MCP servers into `~/.gemini/config/mcp_config.json` without replacing your entire set.
 
-**Important CLAUDE note**: if you already maintain your own `~/.claude/CLAUDE.md` or `~/.claude/CLAUDE.zh-CN.md`, review `~/.claude/CLAUDE.scholar.md` and `~/.claude/CLAUDE.zh-CN.scholar.md` after installation and manually merge the Claude Scholar sections you want into your own files. Do not assume the sidecar files are applied automatically.
+**Important CLAUDE note**: if you already maintain your own `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` or `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`, review the sidecar `.scholar.md` files after installation and manually merge the Claude Scholar sections you want into your own files. Do not assume the sidecar files are applied automatically.
 
 To update later:
 
 ```bash
-cd /tmp/claude-scholar
+cd /tmp/claude-scholar  # or C:\Temp\claude-scholar on Windows
 git pull --ff-only
-bash scripts/setup.sh
+bash scripts/setup.sh   # or powershell -ExecutionPolicy Bypass -File scripts/setup.ps1
 ```
 
 To uninstall later:
@@ -154,8 +159,8 @@ bash scripts/uninstall.sh
 ```
 
 The installer now writes:
-- `~/.claude/.claude-scholar-manifest.txt` for the exact files managed by Claude Scholar
-- `~/.claude/.claude-scholar-install-state` for install ownership metadata used by safe uninstall
+- `~/.gemini/config/plugins/claude-scholar/.claude-scholar-manifest.txt` for the exact files managed by Claude Scholar
+- `~/.gemini/config/plugins/claude-scholar/.claude-scholar-install-state` for install ownership metadata used by safe uninstall
 
 The uninstaller removes only files and settings entries recorded in that install state. It does not guess ownership from the current repo checkout.
 
@@ -164,38 +169,38 @@ The uninstaller removes only files and settings entries recorded in that install
 Install only a small research-focused subset:
 
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
-mkdir -p ~/.claude/hooks ~/.claude/skills
-cp /tmp/claude-scholar/hooks/*.js ~/.claude/hooks/
-cp -r /tmp/claude-scholar/skills/ml-paper-writing ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/research-ideation ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/results-analysis ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/results-report ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/review-response ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/writing-anti-ai ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/git-workflow ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/bug-detective ~/.claude/skills/
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+mkdir -p ~/.gemini/config/plugins/claude-scholar/hooks ~/.gemini/config/plugins/claude-scholar/skills
+cp /tmp/claude-scholar/hooks/*.js ~/.gemini/config/plugins/claude-scholar/hooks/
+cp -r /tmp/claude-scholar/skills/ml-paper-writing ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/research-ideation ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/results-analysis ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/results-report ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/review-response ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/writing-anti-ai ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/git-workflow ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/bug-detective ~/.gemini/config/plugins/claude-scholar/skills/
 ```
 
-**Post-install**: minimal/manual install does **not** auto-merge `settings.json`; copy only the hooks or MCP entries you want from `settings.json.template`. If you already have your own `~/.claude/CLAUDE.md` or `~/.claude/CLAUDE.zh-CN.md`, also merge the relevant sections from this repo's Claude files into yours instead of blindly overwriting them.
+**Post-install**: minimal/manual install does **not** auto-merge `mcp_config.json`; copy only the MCP entries you want from `settings.json.template` to `~/.gemini/config/mcp_config.json`. If you already have your own `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` or `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`, also merge the relevant sections from this repo's Claude files into yours instead of blindly overwriting them.
 
 ### Option 3: Selective Installation
 
 Copy only the parts you need:
 
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
 cd /tmp/claude-scholar
 
-cp hooks/*.js ~/.claude/hooks/
-cp -r skills/latex-conference-template-organizer ~/.claude/skills/
-cp -r skills/architecture-design ~/.claude/skills/
-cp agents/paper-miner.md ~/.claude/agents/
-cp rules/coding-style.md ~/.claude/rules/
-cp rules/agents.md ~/.claude/rules/
+cp hooks/*.js ~/.gemini/config/plugins/claude-scholar/hooks/
+cp -r skills/latex-conference-template-organizer ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r skills/architecture-design ~/.gemini/config/plugins/claude-scholar/skills/
+cp agents/paper-miner.md ~/.gemini/config/plugins/claude-scholar/agents/
+cp rules/coding-style.md ~/.gemini/config/plugins/claude-scholar/rules/
+cp rules/agents.md ~/.gemini/config/plugins/claude-scholar/rules/
 ```
 
-**Post-install**: selective/manual install does **not** auto-merge `settings.json`; copy only the hooks or MCP entries you actually want from `settings.json.template`. If you already have your own `~/.claude/CLAUDE.md` or `~/.claude/CLAUDE.zh-CN.md`, merge the relevant sections from this repo's Claude files into yours instead of blindly overwriting them.
+**Post-install**: selective/manual install does **not** auto-merge `mcp_config.json`; copy only the MCP entries you actually want from `settings.json.template` to `~/.gemini/config/mcp_config.json`. If you already have your own `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` or `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`, merge the relevant sections from this repo's Claude files into yours instead of blindly overwriting them.
 
 ### Option 4: Plugin Marketplace Installation
 
@@ -213,18 +218,18 @@ This auto-loads all skills, commands, agents, and hooks. During installation, yo
 Claude Code plugins cannot distribute rules automatically. Install them manually:
 
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
 
 # User-level (all projects)
-mkdir -p ~/.claude/rules
-cp /tmp/claude-scholar/rules/*.md ~/.claude/rules/
+mkdir -p ~/.gemini/config/plugins/claude-scholar/rules
+cp /tmp/claude-scholar/rules/*.md ~/.gemini/config/plugins/claude-scholar/rules/
 
 # Or project-level (current project only)
 mkdir -p .claude/rules
 cp /tmp/claude-scholar/rules/*.md .claude/rules/
 ```
 
-**Post-install**: plugin installation does **not** auto-load `CLAUDE.md` or configure `settings.json`; if you already have your own `~/.claude/CLAUDE.md` or `~/.claude/CLAUDE.zh-CN.md`, merge the relevant Claude Scholar sections into yours instead of assuming the plugin applies them automatically. If you need Zotero MCP or other integrations, see the [Integrations](#integrations) section for manual setup.
+**Post-install**: plugin installation does **not** auto-load `CLAUDE.md` or configure `mcp_config.json`; if you already have your own `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` or `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`, merge the relevant Claude Scholar sections into yours instead of assuming the plugin applies them automatically. If you need Zotero MCP or other integrations, see the [Integrations](#integrations) section for manual setup.
 
 ## Getting Started Scenarios
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,30 +119,35 @@ Claude Scholar 将研究工作路由为一条可追踪路径：
 
 ### 选项 1：完整安装（推荐）
 
+**Linux / macOS**：
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
 bash /tmp/claude-scholar/scripts/setup.sh
 ```
 
-**Windows**：请使用 Git Bash / WSL 运行安装脚本。
+**Windows (PowerShell)**：
+```powershell
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git C:\Temp\claude-scholar
+powershell -ExecutionPolicy Bypass -File C:\Temp\claude-scholar\scripts\setup.ps1
+```
 
 安装器现在支持**带备份的安全增量更新**：
-- 更新仓库托管的 `skills/commands/agents/rules/hooks/scripts/CLAUDE*.md`
-- 将被覆盖的文件备份到 `~/.claude/.claude-scholar-backups/<timestamp>/`
-- 同时把 `settings.json` 备份为 `settings.json.bak`
-- 如果已存在 `~/.claude/CLAUDE.md`，则保留原文件，并把仓库版本另存为 `~/.claude/CLAUDE.scholar.md`
-- 如果已存在 `~/.claude/CLAUDE.zh-CN.md`，则保留原文件，并把仓库版本另存为 `~/.claude/CLAUDE.zh-CN.scholar.md`
+- 更新仓库托管的 `skills/commands/agents/rules/hooks/scripts/CLAUDE*.md` 直接到插件目录 `~/.gemini/config/plugins/claude-scholar/`
+- 将被覆盖的文件备份到 `~/.gemini/config/plugins/claude-scholar/.claude-scholar-backups/<timestamp>/`
+- 同时把 `mcp_config.json` 备份为 `mcp_config.json.bak`
+- 如果已存在 `~/.gemini/config/plugins/claude-scholar/CLAUDE.md`，则保留原文件，并把仓库版本另存为 `~/.gemini/config/plugins/claude-scholar/CLAUDE.scholar.md`
+- 如果已存在 `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`，则保留原文件，并把仓库版本另存为 `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.scholar.md`
 - 保留已有的 `env`、模型/provider 配置、API key、permissions，以及当前 `mcpServers` 的现有取值
-- 对 hooks 采用追加缺失项的方式，而不是整体替换
+- 将所需的 MCP 服务合并到 `~/.gemini/config/mcp_config.json`，而不会替换你现有的全部配置
 
-**重要 CLAUDE 说明**：如果你原来就有自己的 `~/.claude/CLAUDE.md` 或 `~/.claude/CLAUDE.zh-CN.md`，安装后请查看 `~/.claude/CLAUDE.scholar.md` 和 `~/.claude/CLAUDE.zh-CN.scholar.md`，并将其中你需要的 Claude Scholar 内容按需合并到你自己的文件里；不要假设这些旁路文件会自动生效。
+**重要 CLAUDE 说明**：如果你原来就有自己的 `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` 或 `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`，安装后请查看旁路的 `.scholar.md` 文件，并将其中你需要的 Claude Scholar 内容按需合并到你自己的文件里；不要假设这些旁路文件会自动生效。
 
 以后做增量更新时：
 
 ```bash
-cd /tmp/claude-scholar
+cd /tmp/claude-scholar  # Windows 下为 C:\Temp\claude-scholar
 git pull --ff-only
-bash scripts/setup.sh
+bash scripts/setup.sh   # Windows 下为 powershell -ExecutionPolicy Bypass -File scripts/setup.ps1
 ```
 
 以后如果要卸载：
@@ -153,8 +158,8 @@ bash scripts/uninstall.sh
 ```
 
 安装器现在还会写入：
-- `~/.claude/.claude-scholar-manifest.txt`：记录 Claude Scholar 实际管理的文件
-- `~/.claude/.claude-scholar-install-state`：记录安全卸载所需的 ownership 元数据
+- `~/.gemini/config/plugins/claude-scholar/.claude-scholar-manifest.txt`：记录 Claude Scholar 实际管理的文件
+- `~/.gemini/config/plugins/claude-scholar/.claude-scholar-install-state`：记录安全卸载所需的 ownership 元数据
 
 卸载脚本只会删除 install state 中明确记录的文件和 settings 条目，不会再根据当前 repo 工作树去猜测所有权。
 
@@ -163,38 +168,38 @@ bash scripts/uninstall.sh
 只安装一组较小的研究工作流子集：
 
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
-mkdir -p ~/.claude/hooks ~/.claude/skills
-cp /tmp/claude-scholar/hooks/*.js ~/.claude/hooks/
-cp -r /tmp/claude-scholar/skills/ml-paper-writing ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/research-ideation ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/results-analysis ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/results-report ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/review-response ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/writing-anti-ai ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/git-workflow ~/.claude/skills/
-cp -r /tmp/claude-scholar/skills/bug-detective ~/.claude/skills/
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+mkdir -p ~/.gemini/config/plugins/claude-scholar/hooks ~/.gemini/config/plugins/claude-scholar/skills
+cp /tmp/claude-scholar/hooks/*.js ~/.gemini/config/plugins/claude-scholar/hooks/
+cp -r /tmp/claude-scholar/skills/ml-paper-writing ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/research-ideation ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/results-analysis ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/results-report ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/review-response ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/writing-anti-ai ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/git-workflow ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r /tmp/claude-scholar/skills/bug-detective ~/.gemini/config/plugins/claude-scholar/skills/
 ```
 
-**安装后**：最小化/手动安装**不会自动合并** `settings.json`；请按需从 `settings.json.template` 复制你需要的 hooks 或 MCP 条目。如果你已经有自己的 `~/.claude/CLAUDE.md` 或 `~/.claude/CLAUDE.zh-CN.md`，也请把仓库提供的相关内容按需合并到你的文件里，而不是直接覆盖。
+**安装后**：最小化/手动安装**不会自动合并** `mcp_config.json`；请按需从 `settings.json.template` 复制你需要的 MCP 条目到 `~/.gemini/config/mcp_config.json`。如果你已经有自己的 `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` 或 `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`，也请把仓库提供的相关内容按需合并到你的文件里，而不是直接覆盖。
 
 ### 选项 3：选择性安装
 
 只复制你需要的部分：
 
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
 cd /tmp/claude-scholar
 
-cp hooks/*.js ~/.claude/hooks/
-cp -r skills/latex-conference-template-organizer ~/.claude/skills/
-cp -r skills/architecture-design ~/.claude/skills/
-cp agents/paper-miner.md ~/.claude/agents/
-cp rules/coding-style.md ~/.claude/rules/
-cp rules/agents.md ~/.claude/rules/
+cp hooks/*.js ~/.gemini/config/plugins/claude-scholar/hooks/
+cp -r skills/latex-conference-template-organizer ~/.gemini/config/plugins/claude-scholar/skills/
+cp -r skills/architecture-design ~/.gemini/config/plugins/claude-scholar/skills/
+cp agents/paper-miner.md ~/.gemini/config/plugins/claude-scholar/agents/
+cp rules/coding-style.md ~/.gemini/config/plugins/claude-scholar/rules/
+cp rules/agents.md ~/.gemini/config/plugins/claude-scholar/rules/
 ```
 
-**安装后**：选择性/手动安装**不会自动合并** `settings.json`；请按需从 `settings.json.template` 复制你需要的 hooks 或 MCP 条目。如果你已经有自己的 `~/.claude/CLAUDE.md` 或 `~/.claude/CLAUDE.zh-CN.md`，也请把仓库提供的相关内容按需合并到你的文件里，而不是直接覆盖。
+**安装后**：选择性/手动安装**不会自动合并** `mcp_config.json`；请按需从 `settings.json.template` 复制你需要的 MCP 条目到 `~/.gemini/config/mcp_config.json`。如果你已经有自己的 `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` 或 `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`，也请把仓库提供的相关内容按需合并到你的文件里，而不是直接覆盖。
 
 ### 选项 4：插件市场安装
 
@@ -212,18 +217,18 @@ cp rules/agents.md ~/.claude/rules/
 Claude Code 插件无法自动分发 rules，需要手动安装：
 
 ```bash
-git clone https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
+git clone -b antigravity https://github.com/Galaxy-Dawn/claude-scholar.git /tmp/claude-scholar
 
 # 用户级（所有项目生效）
-mkdir -p ~/.claude/rules
-cp /tmp/claude-scholar/rules/*.md ~/.claude/rules/
+mkdir -p ~/.gemini/config/plugins/claude-scholar/rules
+cp /tmp/claude-scholar/rules/*.md ~/.gemini/config/plugins/claude-scholar/rules/
 
 # 或项目级（仅当前项目生效）
 mkdir -p .claude/rules
 cp /tmp/claude-scholar/rules/*.md .claude/rules/
 ```
 
-**安装后**：插件安装**不会**自动加载 `CLAUDE.md` 或配置 `settings.json`；如果你已经有自己的 `~/.claude/CLAUDE.md` 或 `~/.claude/CLAUDE.zh-CN.md`，也请把仓库提供的相关内容按需合并到你的文件里，而不是假设插件会自动应用。如需 Zotero MCP 或其他集成，请参阅[集成能力](#集成能力)部分手动设置。
+**安装后**：插件安装**不会**自动加载 `CLAUDE.md` 或配置 `mcp_config.json`；如果你已经有自己的 `~/.gemini/config/plugins/claude-scholar/CLAUDE.md` 或 `~/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md`，也请把仓库提供的相关内容按需合并到你的文件里，而不是假设插件会自动应用。如需 Zotero MCP 或其他集成，请参阅[集成能力](#集成能力)部分手动设置。
 
 ## 上手场景
 

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,517 @@
+﻿# scripts/setup.ps1
+# PowerShell-native port of Claude Scholar Installer for Antigravity 2.0 native plugin structure
+
+$ErrorActionPreference = "Stop"
+
+$CLAUDE_DIR = "$env:USERPROFILE\.gemini\config\plugins\claude-scholar"
+$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SRC_DIR = Split-Path -Parent $SCRIPT_DIR
+$COMPONENTS = @('skills', 'commands', 'agents', 'rules', 'hooks', 'scripts', 'templates')
+$CLAUDE_MD_SIDECAR = "CLAUDE.scholar.md"
+$CLAUDE_ZH_MD_SIDECAR = "CLAUDE.zh-CN.scholar.md"
+$BACKUP_ROOT = Join-Path $CLAUDE_DIR ".claude-scholar-backups"
+$MANIFEST_FILE = Join-Path $CLAUDE_DIR ".claude-scholar-manifest.txt"
+$STATE_FILE = Join-Path $CLAUDE_DIR ".claude-scholar-install-state"
+$BACKUP_STAMP = (Get-Date -Format "yyyyMMdd-HHmmss")
+$BACKUP_DIR = Join-Path $BACKUP_ROOT $BACKUP_STAMP
+$BACKUP_READY = $false
+$BACKUP_COUNT = 0
+$UPDATED_COUNT = 0
+$SKIPPED_COUNT = 0
+$SETTINGS_CREATED = 0
+$MANAGED_PATHS = [System.Collections.Generic.List[string]]::new()
+$CLAUDE_TARGETS = [System.Collections.Generic.List[string]]::new()
+$SETTINGS_META_FILE = [System.IO.Path]::GetTempFileName()
+$LEGACY_INSTALL_DETECTED = $false
+
+$PREVIOUS_MANAGED_PATHS = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+# Helper functions
+function Write-Info($msg) {
+    Write-Host "[INFO] $msg" -ForegroundColor Cyan
+}
+
+function Write-Warn($msg) {
+    Write-Host "[WARN] $msg" -ForegroundColor Yellow
+}
+
+function Write-Err($msg) {
+    Write-Host "[ERROR] $msg" -ForegroundColor Red
+    exit 1
+}
+
+function Get-RelativePath($path, $base) {
+    $absPath = [System.IO.Path]::GetFullPath($path).Replace('\', '/')
+    $absBase = [System.IO.Path]::GetFullPath($base).Replace('\', '/')
+    if (-not $absBase.EndsWith('/')) {
+        $absBase += '/'
+    }
+    if ($absPath.StartsWith($absBase)) {
+        return $absPath.Substring($absBase.Length)
+    }
+    return $null
+}
+
+function Check-Deps {
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Write-Err "Git is required. Install it first."
+    }
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+        Write-Err "Node.js is required (hooks depend on it). Install it first."
+    }
+}
+
+function Load-PreviousManifest {
+    if (Test-Path $MANIFEST_FILE) {
+        $lines = Get-Content -Path $MANIFEST_FILE
+        foreach ($line in $lines) {
+            $trimmed = $line.Trim()
+            if ($trimmed) {
+                [void]$PREVIOUS_MANAGED_PATHS.Add($trimmed)
+            }
+        }
+    }
+}
+
+function Detect-LegacyInstall {
+    $settingsPath = Join-Path $CLAUDE_DIR "settings.json"
+    if (Test-Path $MANIFEST_FILE) { return }
+    if (!(Test-Path $settingsPath)) { return }
+    
+    try {
+        $settingsContent = Get-Content -Raw -Path $settingsPath -ErrorAction SilentlyContinue
+        if (-not $settingsContent) { return }
+        $settings = ConvertFrom-Json $settingsContent
+        
+        $hookNeedles = @(
+            '.claude/hooks/security-guard.js',
+            '.claude/hooks/session-summary.js',
+            '.claude/hooks/session-start.js',
+            '.claude/hooks/stop-summary.js',
+            '.claude/hooks/skill-forced-eval.js'
+        )
+        
+        $detected = $false
+        if ($settings.hooks) {
+            foreach ($matchers in $settings.hooks.PSObject.Properties.Value) {
+                if ($matchers -is [array]) {
+                    foreach ($matcher in $matchers) {
+                        if ($matcher.hooks -is [array]) {
+                            foreach ($hook in $matcher.hooks) {
+                                if ($hook.command -is [string]) {
+                                    foreach ($needle in $hookNeedles) {
+                                        if ($hook.command.Contains($needle)) {
+                                            $detected = $true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if ($detected) {
+            $global:LEGACY_INSTALL_DETECTED = $true
+        }
+    } catch {
+        # ignore parsing error
+    }
+}
+
+function Record-ManagedPath($targetPath) {
+    $rel = Get-RelativePath $targetPath $CLAUDE_DIR
+    if (-not $rel) { return }
+    if (-not $MANAGED_PATHS.Contains($rel)) {
+        [void]$MANAGED_PATHS.Add($rel)
+    }
+}
+
+function Record-ClaudeTarget($targetPath) {
+    $rel = Get-RelativePath $targetPath $CLAUDE_DIR
+    if (-not $rel) { return }
+    if (-not $CLAUDE_TARGETS.Contains($rel)) {
+        [void]$CLAUDE_TARGETS.Add($rel)
+    }
+}
+
+function Was-PreviouslyManaged($targetPath) {
+    $rel = Get-RelativePath $targetPath $CLAUDE_DIR
+    if (-not $rel) { return $false }
+    return $PREVIOUS_MANAGED_PATHS.Contains($rel)
+}
+
+function Should-AdoptExistingPath($targetPath) {
+    if (Was-PreviouslyManaged $targetPath) {
+        return $true
+    }
+    return $global:LEGACY_INSTALL_DETECTED
+}
+
+function Ensure-BackupDir {
+    if (-not $global:BACKUP_READY) {
+        New-Item -ItemType Directory -Force -Path $BACKUP_DIR | Out-Null
+        $global:BACKUP_READY = $true
+        Write-Info "Backup directory: $BACKUP_DIR"
+    }
+}
+
+function Backup-Path($targetPath) {
+    if (-not (Test-Path $targetPath)) { return }
+    Ensure-BackupDir
+    
+    $rel = Get-RelativePath $targetPath $CLAUDE_DIR
+    if (-not $rel) {
+        $rel = Split-Path -Leaf $targetPath
+    }
+    
+    $dest = Join-Path $BACKUP_DIR $rel
+    $destParent = Split-Path -Parent $dest
+    if (-not (Test-Path $destParent)) {
+        New-Item -ItemType Directory -Force -Path $destParent | Out-Null
+    }
+    
+    if (Test-Path -Path $targetPath -PathType Container) {
+        Copy-Item -Recurse -Force -Path $targetPath -Destination $dest | Out-Null
+    } else {
+        Copy-Item -Force -Path $targetPath -Destination $dest | Out-Null
+    }
+    $global:BACKUP_COUNT++
+}
+
+function Create-Settings {
+    $target = "$env:USERPROFILE\.gemini\config\mcp_config.json"
+    if (!(Test-Path $target)) {
+        $parent = Split-Path -Parent $target
+        if (-not (Test-Path $parent)) {
+            New-Item -ItemType Directory -Force -Path $parent | Out-Null
+        }
+        Set-Content -Path $target -Value '{"mcpServers": {}}' -Encoding utf8
+        $global:SETTINGS_CREATED = 1
+        Write-Info "Created empty mcp_config.json."
+    }
+}
+
+function Merge-Settings($srcDir) {
+    $template = Join-Path $srcDir "settings.json.template"
+    $target = "$env:USERPROFILE\.gemini\config\mcp_config.json"
+    
+    if (!(Test-Path $template)) { return }
+    if (!(Test-Path $target)) { Create-Settings }
+    
+    Backup-Path $target
+    
+    $bak = "$target.bak"
+    Copy-Item -Force -Path $target -Destination $bak | Out-Null
+    Write-Info "Backed up mcp_config.json -> mcp_config.json.bak"
+    
+    $env:CLAUDE_SETTINGS_TARGET = $target
+    $env:CLAUDE_SETTINGS_TEMPLATE = $template
+    $env:CLAUDE_SETTINGS_META_FILE = $SETTINGS_META_FILE
+    
+    $nodeScript = @"
+const fs = require('fs');
+const targetPath = process.env.CLAUDE_SETTINGS_TARGET;
+const templatePath = process.env.CLAUDE_SETTINGS_TEMPLATE;
+const metaPath = process.env.CLAUDE_SETTINGS_META_FILE;
+const existing = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
+const template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
+const addedMcpServers = [];
+const addedMcpServerFields = {};
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function mergeMissing(existingValue, templateValue, pathParts, addedPaths) {
+  if (existingValue === undefined) return clone(templateValue);
+  if (templateValue === null || Array.isArray(templateValue) || typeof templateValue !== 'object') {
+    return existingValue;
+  }
+
+  const output = { ...existingValue };
+  for (const [key, value] of Object.entries(templateValue)) {
+    if (!(key in output)) {
+      output[key] = clone(value);
+      addedPaths.push([...pathParts, key].join('.'));
+      continue;
+    }
+    if (
+      output[key] &&
+      value &&
+      !Array.isArray(output[key]) &&
+      !Array.isArray(value) &&
+      typeof output[key] === 'object' &&
+      typeof value === 'object'
+    ) {
+      output[key] = mergeMissing(output[key], value, [...pathParts, key], addedPaths);
+    }
+  }
+  return output;
+}
+
+existing.mcpServers = existing.mcpServers || {};
+
+if (template.mcpServers) {
+  for (const [key, value] of Object.entries(template.mcpServers)) {
+    if (!(key in existing.mcpServers)) {
+      addedMcpServers.push(key);
+      existing.mcpServers[key] = clone(value);
+      continue;
+    }
+    const addedPaths = [];
+    existing.mcpServers[key] = mergeMissing(existing.mcpServers[key], value, [], addedPaths);
+    if (addedPaths.length > 0) {
+      addedMcpServerFields[key] = addedPaths;
+    }
+  }
+}
+
+fs.writeFileSync(targetPath, JSON.stringify(existing, null, 2) + '\n');
+fs.writeFileSync(metaPath, JSON.stringify({
+  addedHooks: [],
+  addedMcpServers,
+  addedMcpServerFields,
+  addedEnabledPlugins: [],
+}, null, 2) + '\n');
+"@
+
+    $tempJs = [System.IO.Path]::GetTempFileName() + ".js"
+    Set-Content -Path $tempJs -Value $nodeScript -Encoding utf8
+    
+    $process = Start-Process node -ArgumentList $tempJs -NoNewWindow -PassThru -Wait
+    Remove-Item -Path $tempJs -Force -ErrorAction SilentlyContinue
+    
+    if ($process.ExitCode -ne 0) {
+        Write-Warning "Auto-merge failed. Please manually copy mcpServers from settings.json.template."
+    } else {
+        Write-Info "Merged mcpServers into mcp_config.json without touching existing configurations."
+    }
+}
+
+function Copy-FileSafely($srcFile, $targetFile) {
+    $parent = Split-Path -Parent $targetFile
+    if (-not (Test-Path $parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    
+    if (Test-Path $targetFile) {
+        $srcHash = Get-FileHash -Path $srcFile -Algorithm SHA256
+        $targetHash = Get-FileHash -Path $targetFile -Algorithm SHA256
+        if ($srcHash.Hash -eq $targetHash.Hash) {
+            if (Should-AdoptExistingPath $targetFile) {
+                Record-ManagedPath $targetFile
+            }
+            $global:SKIPPED_COUNT++
+            return
+        }
+    }
+    
+    if (Test-Path $targetFile) {
+        Backup-Path $targetFile
+        if (Test-Path -Path $targetFile -PathType Container) {
+            Remove-Item -Recurse -Force -Path $targetFile | Out-Null
+        }
+    }
+    
+    Copy-Item -Force -Path $srcFile -Destination $targetFile | Out-Null
+    Record-ManagedPath $targetFile
+    $global:UPDATED_COUNT++
+}
+
+function Copy-DirSafely($srcDir, $targetDir) {
+    if (Test-Path $targetDir) {
+        if (-not (Test-Path -Path $targetDir -PathType Container)) {
+            Backup-Path $targetDir
+            Remove-Item -Force -Path $targetDir | Out-Null
+        }
+    }
+    New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+    
+    $files = Get-ChildItem -Path $srcDir -Recurse -File
+    foreach ($file in $files) {
+        $rel = Get-RelativePath $file.FullName $srcDir
+        $targetFile = Join-Path $targetDir $rel
+        Copy-FileSafely $file.FullName $targetFile
+    }
+}
+
+function Install-ClaudeMd($srcFile) {
+    $targetFile = Join-Path $CLAUDE_DIR "CLAUDE.md"
+    $sidecarFile = Join-Path $CLAUDE_DIR $CLAUDE_MD_SIDECAR
+    
+    if ((Test-Path $targetFile) -and (Should-AdoptExistingPath $targetFile)) {
+        Copy-FileSafely $srcFile $targetFile
+        Record-ClaudeTarget $targetFile
+        return
+    }
+    
+    if (Test-Path $targetFile) {
+        Write-Warn "Preserving existing CLAUDE.md"
+        Copy-FileSafely $srcFile $sidecarFile
+        Record-ClaudeTarget $sidecarFile
+        Write-Info "Installed repository CLAUDE.md as $CLAUDE_MD_SIDECAR"
+        return
+    }
+    
+    Copy-FileSafely $srcFile $targetFile
+    Record-ClaudeTarget $targetFile
+}
+
+function Install-ClaudeZhMd($srcFile) {
+    $targetFile = Join-Path $CLAUDE_DIR "CLAUDE.zh-CN.md"
+    $sidecarFile = Join-Path $CLAUDE_DIR $CLAUDE_ZH_MD_SIDECAR
+    
+    if ((Test-Path $targetFile) -and (Should-AdoptExistingPath $targetFile)) {
+        Copy-FileSafely $srcFile $targetFile
+        Record-ClaudeTarget $targetFile
+        return
+    }
+    
+    if (Test-Path $targetFile) {
+        Write-Warn "Preserving existing CLAUDE.zh-CN.md"
+        Copy-FileSafely $srcFile $sidecarFile
+        Record-ClaudeTarget $sidecarFile
+        Write-Info "Installed repository CLAUDE.zh-CN.md as $CLAUDE_ZH_MD_SIDECAR"
+        return
+    }
+    
+    Copy-FileSafely $srcFile $targetFile
+    Record-ClaudeTarget $targetFile
+}
+
+function Copy-Components($src) {
+    $pluginJson = Join-Path $src ".claude-plugin\plugin.json"
+    if (Test-Path $pluginJson) {
+        Copy-FileSafely $pluginJson (Join-Path $CLAUDE_DIR "plugin.json")
+        Copy-FileSafely $pluginJson (Join-Path $CLAUDE_DIR "plugins.json")
+    }
+    
+    $claudeMd = Join-Path $src "CLAUDE.md"
+    if (Test-Path $claudeMd) {
+        Install-ClaudeMd $claudeMd
+    }
+    
+    $claudeZhMd = Join-Path $src "CLAUDE.zh-CN.md"
+    if (Test-Path $claudeZhMd) {
+        Install-ClaudeZhMd $claudeZhMd
+    }
+    
+    foreach ($comp in $COMPONENTS) {
+        $compPath = Join-Path $src $comp
+        if (Test-Path $compPath) {
+            $destPath = Join-Path $CLAUDE_DIR $comp
+            if (Test-Path -Path $compPath -PathType Container) {
+                Copy-DirSafely $compPath $destPath
+            } else {
+                Copy-FileSafely $compPath $destPath
+            }
+        }
+    }
+    
+    Write-Info "Updated components: $($COMPONENTS -join ' ')"
+}
+
+function Write-InstallState {
+    if (-not (Test-Path $CLAUDE_DIR)) {
+        New-Item -ItemType Directory -Force -Path $CLAUDE_DIR | Out-Null
+    }
+    
+    $uniqueManaged = $MANAGED_PATHS | Sort-Object -Unique
+    if ($uniqueManaged) {
+        Set-Content -Path $MANIFEST_FILE -Value $uniqueManaged -Encoding utf8
+    } else {
+        Clear-Content -Path $MANIFEST_FILE -ErrorAction SilentlyContinue
+    }
+    
+    $managedPathsTemp = [System.IO.Path]::GetTempFileName()
+    $claudeTargetsTemp = [System.IO.Path]::GetTempFileName()
+    
+    if ($MANAGED_PATHS) {
+        $MANAGED_PATHS | Sort-Object -Unique | Set-Content -Path $managedPathsTemp -Encoding utf8
+    }
+    if ($CLAUDE_TARGETS) {
+        $CLAUDE_TARGETS | Sort-Object -Unique | Set-Content -Path $claudeTargetsTemp -Encoding utf8
+    }
+    
+    $env:CLAUDE_STATE_FILE = $STATE_FILE
+    $env:CLAUDE_SETTINGS_META_FILE = $SETTINGS_META_FILE
+    $env:CLAUDE_MANAGED_PATHS_FILE = $managedPathsTemp
+    $env:CLAUDE_TARGETS_FILE = $claudeTargetsTemp
+    $env:CLAUDE_INSTALLED_AT = $BACKUP_STAMP
+    $env:CLAUDE_SOURCE_DIR = $SRC_DIR
+    $env:CLAUDE_SETTINGS_CREATED = $SETTINGS_CREATED.ToString()
+    $env:CLAUDE_BACKUP_DIR = $BACKUP_DIR
+    $env:CLAUDE_BACKUP_READY = if ($BACKUP_READY) { "1" } else { "0" }
+    
+    $nodeScript = @"
+const fs = require('fs');
+
+function readLines(path) {
+  if (!path || !fs.existsSync(path)) return [];
+  return fs.readFileSync(path, 'utf8').split('\n').map((line) => line.trim()).filter(Boolean);
+}
+
+function readJson(path) {
+  if (!path || !fs.existsSync(path)) return {};
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+const state = {
+  installedAt: process.env.CLAUDE_INSTALLED_AT,
+  sourceDir: process.env.CLAUDE_SOURCE_DIR,
+  settingsCreated: process.env.CLAUDE_SETTINGS_CREATED === '1',
+  backupDir: process.env.CLAUDE_BACKUP_READY === '1' ? process.env.CLAUDE_BACKUP_DIR : '',
+  managedPaths: readLines(process.env.CLAUDE_MANAGED_PATHS_FILE),
+  claudeTargets: readLines(process.env.CLAUDE_TARGETS_FILE),
+  settings: readJson(process.env.CLAUDE_SETTINGS_META_FILE),
+};
+
+fs.writeFileSync(process.env.CLAUDE_STATE_FILE, JSON.stringify(state, null, 2) + '\n');
+"@
+
+    $tempJs = [System.IO.Path]::GetTempFileName() + ".js"
+    Set-Content -Path $tempJs -Value $nodeScript -Encoding utf8
+    node $tempJs
+    Remove-Item -Path $tempJs -Force -ErrorAction SilentlyContinue
+    
+    Remove-Item -Path $managedPathsTemp -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $claudeTargetsTemp -Force -ErrorAction SilentlyContinue
+}
+
+function Main {
+    Write-Host ""
+    Write-Host "╔══════════════════════════════════════╗" -ForegroundColor Cyan
+    Write-Host "║       Claude Scholar Installer       ║" -ForegroundColor Cyan
+    Write-Host "╚══════════════════════════════════════╝" -ForegroundColor Cyan
+    Write-Host ""
+    
+    Check-Deps
+    Load-PreviousManifest
+    Detect-LegacyInstall
+    
+    Write-Info "Installing from: $SRC_DIR"
+    Copy-Components $SRC_DIR
+    Merge-Settings $SRC_DIR
+    Write-InstallState
+    
+    Write-Info "Your existing env/model/API key/permissions settings are preserved."
+    Write-Info "Install manifest: $MANIFEST_FILE"
+    Write-Info "Updated files: $global:UPDATED_COUNT | Unchanged files skipped: $global:SKIPPED_COUNT | Backups created: $global:BACKUP_COUNT"
+    
+    if ($global:BACKUP_READY) {
+        Write-Info "Recover previous files from: $BACKUP_DIR"
+    }
+    
+    Write-Host ""
+    Write-Info "Done! Restart Claude Code CLI to activate."
+    Write-Host ""
+}
+
+try {
+    Main
+} finally {
+    if (Test-Path $SETTINGS_META_FILE) {
+        Remove-Item -Path $SETTINGS_META_FILE -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CLAUDE_DIR="$HOME/.claude"
+CLAUDE_DIR="$HOME/.gemini/config/plugins/claude-scholar"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPONENTS=(skills commands agents rules hooks scripts templates)
@@ -203,59 +203,31 @@ backup_path() {
   BACKUP_COUNT=$((BACKUP_COUNT + 1))
 }
 
-# Create settings.json from template
+# Create mcp_config.json if not present
 create_settings() {
-  local template="$1/settings.json.template"
-  local target="$CLAUDE_DIR/settings.json"
-  if [ -f "$template" ] && [ ! -f "$target" ]; then
-    cp "$template" "$target"
+  local target="$HOME/.gemini/config/mcp_config.json"
+  if [ ! -f "$target" ]; then
+    mkdir -p "$(dirname "$target")"
+    echo '{"mcpServers": {}}' > "$target"
     SETTINGS_CREATED=1
-    CLAUDE_SETTINGS_TEMPLATE="$template" CLAUDE_SETTINGS_META_FILE="$SETTINGS_META_FILE" node <<'NODE'
-const fs = require('fs');
-
-const template = JSON.parse(fs.readFileSync(process.env.CLAUDE_SETTINGS_TEMPLATE, 'utf8'));
-
-const addedHooks = [];
-for (const [eventName, matchers] of Object.entries(template.hooks || {})) {
-  for (const matcher of matchers || []) {
-    for (const hook of matcher.hooks || []) {
-      addedHooks.push({
-        event: eventName,
-        matcher: matcher.matcher || '*',
-        type: hook.type || '',
-        command: hook.command || '',
-        timeout: hook.timeout ?? null,
-      });
-    }
-  }
-}
-
-fs.writeFileSync(process.env.CLAUDE_SETTINGS_META_FILE, JSON.stringify({
-  addedHooks,
-  addedMcpServers: Object.keys(template.mcpServers || {}),
-  addedMcpServerFields: {},
-  addedEnabledPlugins: Object.keys(template.enabledPlugins || {}),
-}, null, 2) + '\n');
-NODE
-    info "Created settings.json from template."
-    info "  → Edit $target to add your GITHUB_PERSONAL_ACCESS_TOKEN (optional)."
+    info "Created empty mcp_config.json."
   fi
 }
 
-# Merge hooks, mcpServers, enabledPlugins from template into existing settings.json
+# Merge mcpServers from template into mcp_config.json
 merge_settings() {
   local template="$1/settings.json.template"
-  local target="$CLAUDE_DIR/settings.json"
+  local target="$HOME/.gemini/config/mcp_config.json"
 
   [ -f "$template" ] || return 0
-  [ -f "$target" ]   || { create_settings "$1"; return 0; }
+  [ -f "$target" ]   || { create_settings "$1"; }
 
   # Backup
   backup_path "$target"
   cp "$target" "${target}.bak"
-  info "Backed up settings.json → settings.json.bak"
+  info "Backed up mcp_config.json → mcp_config.json.bak"
 
-  # Merge hooks, mcpServers, enabledPlugins while preserving user env/model/API key settings.
+  # Merge mcpServers while preserving user configurations
   CLAUDE_SETTINGS_TARGET="$target" CLAUDE_SETTINGS_TEMPLATE="$template" CLAUDE_SETTINGS_META_FILE="$SETTINGS_META_FILE" node <<'NODE'
 const fs = require('fs');
 
@@ -264,10 +236,8 @@ const templatePath = process.env.CLAUDE_SETTINGS_TEMPLATE;
 const metaPath = process.env.CLAUDE_SETTINGS_META_FILE;
 const existing = JSON.parse(fs.readFileSync(targetPath, 'utf8'));
 const template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
-const addedHooks = [];
 const addedMcpServers = [];
 const addedMcpServerFields = {};
-const addedEnabledPlugins = [];
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
@@ -300,66 +270,9 @@ function mergeMissing(existingValue, templateValue, pathParts, addedPaths) {
   return output;
 }
 
-function mergeHooks(existingHooks, templateHooks) {
-  const output = existingHooks ? clone(existingHooks) : {};
-  for (const [eventName, templateMatchers] of Object.entries(templateHooks || {})) {
-    const existingMatchers = Array.isArray(output[eventName]) ? output[eventName] : [];
-    for (const templateMatcher of templateMatchers) {
-      const matchValue = templateMatcher.matcher || '*';
-      let existingMatcher = existingMatchers.find((item) => (item.matcher || '*') === matchValue);
-      if (!existingMatcher) {
-        existingMatchers.push(clone(templateMatcher));
-        for (const hook of templateMatcher.hooks || []) {
-          addedHooks.push({
-            event: eventName,
-            matcher: matchValue,
-            type: hook.type || '',
-            command: hook.command || '',
-            timeout: hook.timeout ?? null,
-          });
-        }
-        continue;
-      }
-
-      existingMatcher.hooks = Array.isArray(existingMatcher.hooks) ? existingMatcher.hooks : [];
-      const seen = new Set(
-        existingMatcher.hooks.map((hook) =>
-          JSON.stringify({
-            type: hook.type || '',
-            command: hook.command || '',
-            timeout: hook.timeout ?? null,
-          }),
-        ),
-      );
-
-      for (const hook of templateMatcher.hooks || []) {
-        const signature = JSON.stringify({
-          type: hook.type || '',
-          command: hook.command || '',
-          timeout: hook.timeout ?? null,
-        });
-        if (!seen.has(signature)) {
-          existingMatcher.hooks.push(clone(hook));
-          seen.add(signature);
-          addedHooks.push({
-            event: eventName,
-            matcher: matchValue,
-            type: hook.type || '',
-            command: hook.command || '',
-            timeout: hook.timeout ?? null,
-          });
-        }
-      }
-    }
-    output[eventName] = existingMatchers;
-  }
-  return output;
-}
-
-existing.hooks = mergeHooks(existing.hooks, template.hooks);
+existing.mcpServers = existing.mcpServers || {};
 
 if (template.mcpServers) {
-  existing.mcpServers = existing.mcpServers || {};
   for (const [key, value] of Object.entries(template.mcpServers)) {
     if (!(key in existing.mcpServers)) {
       addedMcpServers.push(key);
@@ -374,32 +287,22 @@ if (template.mcpServers) {
   }
 }
 
-if (template.enabledPlugins) {
-  existing.enabledPlugins = existing.enabledPlugins || {};
-  for (const [key, value] of Object.entries(template.enabledPlugins)) {
-    if (!(key in existing.enabledPlugins)) {
-      existing.enabledPlugins[key] = value;
-      addedEnabledPlugins.push(key);
-    }
-  }
-}
-
 fs.writeFileSync(targetPath, JSON.stringify(existing, null, 2) + '\n');
 fs.writeFileSync(metaPath, JSON.stringify({
-  addedHooks,
+  addedHooks: [],
   addedMcpServers,
   addedMcpServerFields,
-  addedEnabledPlugins,
+  addedEnabledPlugins: [],
 }, null, 2) + '\n');
 NODE
 
   local merge_status=$?
   if [ "$merge_status" -ne 0 ]; then
-    warn "Auto-merge failed. Please manually copy settings from settings.json.template."
+    warn "Auto-merge failed. Please manually copy mcpServers from settings.json.template."
     return 0
   fi
 
-  info "Merged hooks/mcpServers/enabledPlugins into settings.json without touching env/model/API key fields."
+  info "Merged mcpServers into mcp_config.json without touching existing configurations."
 }
 
 # Copy one file with backup-aware overwrite
@@ -493,6 +396,11 @@ install_claude_zh_md() {
 
 copy_components() {
   local src="$1"
+
+  if [ -f "$src/.claude-plugin/plugin.json" ]; then
+    copy_file_safely "$src/.claude-plugin/plugin.json" "$CLAUDE_DIR/plugin.json"
+    copy_file_safely "$src/.claude-plugin/plugin.json" "$CLAUDE_DIR/plugins.json"
+  fi
 
   if [ -f "$src/CLAUDE.md" ]; then
     install_claude_md "$src/CLAUDE.md"

--- a/scripts/test_install_uninstall.sh
+++ b/scripts/test_install_uninstall.sh
@@ -26,17 +26,17 @@ test_roundtrip_empty_home() {
   home="$(make_home)"
   run_setup "$home"
 
-  test -f "$home/.claude/.claude-scholar-manifest.txt"
-  test -f "$home/.claude/.claude-scholar-install-state"
-  test -f "$home/.claude/CLAUDE.md"
+  test -f "$home/.gemini/config/plugins/claude-scholar/.claude-scholar-manifest.txt"
+  test -f "$home/.gemini/config/plugins/claude-scholar/.claude-scholar-install-state"
+  test -f "$home/.gemini/config/plugins/claude-scholar/CLAUDE.md"
 
   run_uninstall "$home"
 
-  test ! -f "$home/.claude/.claude-scholar-manifest.txt"
-  test ! -f "$home/.claude/.claude-scholar-install-state"
-  test ! -f "$home/.claude/settings.json"
-  if [ -d "$home/.claude" ]; then
-    ! find "$home/.claude"/{skills,commands,agents,rules,hooks,scripts} -type f 2>/dev/null | grep -q .
+  test ! -f "$home/.gemini/config/plugins/claude-scholar/.claude-scholar-manifest.txt"
+  test ! -f "$home/.gemini/config/plugins/claude-scholar/.claude-scholar-install-state"
+  test ! -f "$home/.gemini/config/mcp_config.json"
+  if [ -d "$home/.gemini/config/plugins/claude-scholar" ]; then
+    ! find "$home/.gemini/config/plugins/claude-scholar"/{skills,commands,agents,rules,hooks,scripts} -type f 2>/dev/null | grep -q .
   fi
   pass "roundtrip on empty home"
 }
@@ -44,8 +44,8 @@ test_roundtrip_empty_home() {
 test_preserve_preexisting_settings_keys() {
   local home
   home="$(make_home)"
-  mkdir -p "$home/.claude"
-  python3 - "$home/.claude/settings.json" <<'PY'
+  mkdir -p "$home/.gemini/config"
+  python3 - "$home/.gemini/config/mcp_config.json" <<'PY'
 import json, sys
 path = sys.argv[1]
 data = {
@@ -53,23 +53,6 @@ data = {
         "zotero": {
             "command": "custom-zotero"
         }
-    },
-    "enabledPlugins": {
-        "superpowers@claude-plugins-official": False
-    },
-    "hooks": {
-        "Stop": [
-            {
-                "matcher": "*",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "echo user-hook",
-                        "timeout": 3
-                    }
-                ]
-            }
-        ]
     }
 }
 with open(path, "w", encoding="utf-8") as f:
@@ -80,15 +63,12 @@ PY
   run_setup "$home"
   run_uninstall "$home"
 
-  python3 - "$home/.claude/settings.json" <<'PY'
+  python3 - "$home/.gemini/config/mcp_config.json" <<'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 assert data["mcpServers"]["zotero"]["command"] == "custom-zotero"
 assert "args" not in data["mcpServers"]["zotero"]
 assert "env" not in data["mcpServers"]["zotero"]
-assert data["enabledPlugins"]["superpowers@claude-plugins-official"] is False
-hooks = data["hooks"]["Stop"][0]["hooks"]
-assert len(hooks) == 1 and hooks[0]["command"] == "echo user-hook"
 PY
   pass "preserve pre-existing settings entries with overlapping keys"
 }
@@ -98,15 +78,15 @@ test_manifest_missing_fails_safe() {
   home="$(make_home)"
   run_setup "$home"
 
-  rm -f "$home/.claude/.claude-scholar-manifest.txt"
+  rm -f "$home/.gemini/config/plugins/claude-scholar/.claude-scholar-manifest.txt"
   if HOME="$home" bash "$UNINSTALL_SH" >/tmp/claude-scholar-uninstall-fail.log 2>&1; then
     echo "[FAIL] manifest missing should fail"
     cat /tmp/claude-scholar-uninstall-fail.log
     exit 1
   fi
 
-  test -f "$home/.claude/CLAUDE.md"
-  test -f "$home/.claude/.claude-scholar-install-state"
+  test -f "$home/.gemini/config/plugins/claude-scholar/CLAUDE.md"
+  test -f "$home/.gemini/config/plugins/claude-scholar/.claude-scholar-install-state"
   pass "manifest missing fails safely"
 }
 
@@ -115,7 +95,7 @@ test_state_records_direct_claude_targets() {
   home="$(make_home)"
   run_setup "$home"
 
-  python3 - "$home/.claude/.claude-scholar-install-state" <<'PY'
+  python3 - "$home/.gemini/config/plugins/claude-scholar/.claude-scholar-install-state" <<'PY'
 import json, sys
 state = json.load(open(sys.argv[1], encoding="utf-8"))
 targets = set(state["claudeTargets"])
@@ -124,21 +104,21 @@ assert "CLAUDE.zh-CN.md" in targets, targets
 PY
 
   run_uninstall "$home"
-  test ! -f "$home/.claude/CLAUDE.md"
-  test ! -f "$home/.claude/CLAUDE.zh-CN.md"
+  test ! -f "$home/.gemini/config/plugins/claude-scholar/CLAUDE.md"
+  test ! -f "$home/.gemini/config/plugins/claude-scholar/CLAUDE.zh-CN.md"
   pass "state records direct CLAUDE targets"
 }
 
 test_identical_preexisting_file_is_not_owned() {
   local home
   home="$(make_home)"
-  mkdir -p "$home/.claude/hooks"
-  cp "$REPO_ROOT/hooks/security-guard.js" "$home/.claude/hooks/security-guard.js"
+  mkdir -p "$home/.gemini/config/plugins/claude-scholar/hooks"
+  cp "$REPO_ROOT/hooks/security-guard.js" "$home/.gemini/config/plugins/claude-scholar/hooks/security-guard.js"
 
   run_setup "$home"
   run_uninstall "$home"
 
-  test -f "$home/.claude/hooks/security-guard.js"
+  test -f "$home/.gemini/config/plugins/claude-scholar/hooks/security-guard.js"
   pass "identical pre-existing file is not treated as owned"
 }
 
@@ -149,18 +129,18 @@ test_reinstall_keeps_owned_files_owned() {
   run_setup "$home"
   run_uninstall "$home"
 
-  test ! -f "$home/.claude/hooks/security-guard.js"
-  test ! -f "$home/.claude/CLAUDE.md"
+  test ! -f "$home/.gemini/config/plugins/claude-scholar/hooks/security-guard.js"
+  test ! -f "$home/.gemini/config/plugins/claude-scholar/CLAUDE.md"
   pass "reinstall preserves ownership of previously installed files"
 }
 
 test_legacy_install_upgrade_adopts_existing_files() {
   local home
   home="$(make_home)"
-  mkdir -p "$home/.claude/hooks"
-  cp "$REPO_ROOT/CLAUDE.md" "$home/.claude/CLAUDE.md"
-  cp "$REPO_ROOT/hooks/security-guard.js" "$home/.claude/hooks/security-guard.js"
-  python3 - "$home/.claude/settings.json" <<'PY'
+  mkdir -p "$home/.gemini/config/plugins/claude-scholar/hooks"
+  cp "$REPO_ROOT/CLAUDE.md" "$home/.gemini/config/plugins/claude-scholar/CLAUDE.md"
+  cp "$REPO_ROOT/hooks/security-guard.js" "$home/.gemini/config/plugins/claude-scholar/hooks/security-guard.js"
+  python3 - "$home/.gemini/config/plugins/claude-scholar/settings.json" <<'PY'
 import json, sys
 data = {
     "mcpServers": {
@@ -192,17 +172,17 @@ PY
   run_setup "$home"
   run_uninstall "$home"
 
-  test ! -f "$home/.claude/CLAUDE.md"
-  test ! -f "$home/.claude/hooks/security-guard.js"
+  test ! -f "$home/.gemini/config/plugins/claude-scholar/CLAUDE.md"
+  test ! -f "$home/.gemini/config/plugins/claude-scholar/hooks/security-guard.js"
   pass "legacy install upgrade adopts existing managed files"
 }
 
 test_overlapping_mcp_keys_do_not_trigger_legacy_adoption() {
   local home
   home="$(make_home)"
-  mkdir -p "$home/.claude/hooks"
-  cp "$REPO_ROOT/hooks/security-guard.js" "$home/.claude/hooks/security-guard.js"
-  python3 - "$home/.claude/settings.json" <<'PY'
+  mkdir -p "$home/.gemini/config/plugins/claude-scholar/hooks"
+  cp "$REPO_ROOT/hooks/security-guard.js" "$home/.gemini/config/plugins/claude-scholar/hooks/security-guard.js"
+  python3 - "$home/.gemini/config/plugins/claude-scholar/settings.json" <<'PY'
 import json, sys
 data = {
     "mcpServers": {
@@ -222,7 +202,7 @@ PY
   run_setup "$home"
   run_uninstall "$home"
 
-  test -f "$home/.claude/hooks/security-guard.js"
+  test -f "$home/.gemini/config/plugins/claude-scholar/hooks/security-guard.js"
   pass "overlapping MCP keys alone do not trigger legacy adoption"
 }
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CLAUDE_DIR="$HOME/.claude"
+CLAUDE_DIR="$HOME/.gemini/config/plugins/claude-scholar"
 MANIFEST_FILE="$CLAUDE_DIR/.claude-scholar-manifest.txt"
 STATE_FILE="$CLAUDE_DIR/.claude-scholar-install-state"
 BACKUP_ROOT="$CLAUDE_DIR/.claude-scholar-backups"
@@ -111,7 +111,7 @@ cleanup_empty_dirs() {
 }
 
 cleanup_settings() {
-  local settings="$CLAUDE_DIR/settings.json"
+  local settings="$HOME/.gemini/config/mcp_config.json"
   [ -f "$settings" ] || return 0
 
   backup_target "$settings"
@@ -128,28 +128,10 @@ const statePath = process.env.STATE_PATH;
 const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
 const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
 const settingsCreated = Boolean(state.settingsCreated);
-const addedHooks = Array.isArray(state.settings?.addedHooks) ? state.settings.addedHooks : [];
 const addedMcpServers = new Set(Array.isArray(state.settings?.addedMcpServers) ? state.settings.addedMcpServers : []);
 const addedMcpServerFields = state.settings?.addedMcpServerFields && typeof state.settings.addedMcpServerFields === 'object'
   ? state.settings.addedMcpServerFields
   : {};
-const addedEnabledPlugins = new Set(Array.isArray(state.settings?.addedEnabledPlugins) ? state.settings.addedEnabledPlugins : []);
-
-function hookSignature(hook) {
-  return JSON.stringify({
-    type: hook?.type || '',
-    command: hook?.command || '',
-    timeout: hook?.timeout ?? null,
-  });
-}
-
-const ownedHookMatchers = new Map();
-for (const hook of addedHooks) {
-  const key = `${hook.event}::${hook.matcher || '*'}`;
-  const sigs = ownedHookMatchers.get(key) || new Set();
-  sigs.add(hookSignature(hook));
-  ownedHookMatchers.set(key, sigs);
-}
 
 function pruneEmptyContainers(root, parts) {
   for (let i = parts.length - 1; i > 0; i -= 1) {
@@ -178,28 +160,6 @@ function removeNestedPath(root, dottedPath) {
   pruneEmptyContainers(root, parts);
 }
 
-if (settings.hooks && typeof settings.hooks === 'object') {
-  for (const [eventName, matchers] of Object.entries(settings.hooks)) {
-    if (!Array.isArray(matchers)) continue;
-    const nextMatchers = matchers
-      .map((matcher) => {
-        const key = `${eventName}::${matcher.matcher || '*'}`;
-        const owned = ownedHookMatchers.get(key) || new Set();
-        const hooks = Array.isArray(matcher.hooks)
-          ? matcher.hooks.filter((hook) => !owned.has(hookSignature(hook)))
-          : [];
-        return hooks.length > 0 ? { ...matcher, hooks } : null;
-      })
-      .filter(Boolean);
-    if (nextMatchers.length > 0) {
-      settings.hooks[eventName] = nextMatchers;
-    } else {
-      delete settings.hooks[eventName];
-    }
-  }
-  if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
-}
-
 if (settings.mcpServers && typeof settings.mcpServers === 'object') {
   for (const key of addedMcpServers) {
     delete settings.mcpServers[key];
@@ -221,22 +181,13 @@ if (settings.mcpServers && typeof settings.mcpServers === 'object') {
   if (Object.keys(settings.mcpServers).length === 0) delete settings.mcpServers;
 }
 
-if (settings.enabledPlugins && typeof settings.enabledPlugins === 'object') {
-  for (const key of addedEnabledPlugins) {
-    delete settings.enabledPlugins[key];
-  }
-  if (Object.keys(settings.enabledPlugins).length === 0) delete settings.enabledPlugins;
-}
-
-const onlyDefaultTemplateRemainder =
+const onlyEmptyRemainder =
   settingsCreated &&
-  Object.keys(settings).every((key) => ['env', 'verbose'].includes(key)) &&
-  settings.verbose === true &&
-  settings.env &&
-  Object.keys(settings.env).length === 1 &&
-  settings.env.GITHUB_PERSONAL_ACCESS_TOKEN === '<your-github-token-optional>';
+  Object.keys(settings).length === 1 &&
+  settings.mcpServers &&
+  Object.keys(settings.mcpServers).length === 0;
 
-if (onlyDefaultTemplateRemainder) {
+if (onlyEmptyRemainder) {
   fs.unlinkSync(settingsPath);
 } else {
   fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');


### PR DESCRIPTION
## Summary
- What changed?
- Why did it change?

Add compatibility with Antigravity 2.0.

Antigravity 2.0 is not compatible with antigravity 1.x.

I think it needs a new branch, instead of main, so I created branch antigravity2.0

## Affected surfaces
- [ ] main
- [ ] codex
- [ ] opencode
- [x] antigravity
- [ ] README / docs
- [ ] installer
- [ ] skills
- [ ] agents
- [ ] hooks
- [ ] MCP / Obsidian docs
